### PR TITLE
Add Android build setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
-This repo hosts the official MediaPipe samples with a goal of showing the fundamental steps involved to create apps with our machine learning platform. 
+This repo hosts the official MediaPipe samples with a goal of showing the fundamental steps involved to create apps with our machine learning platform.
 
 External PRs for fixes are welcome, however new sample/demo PRs will likely be rejected to maintain the simplicity of this repo for ongoing maintenance. It is strongly recommended that contributors who are interested in submitting more complex samples or demos host their samples in their own public repos and create written tutorials to share with the community. Contributors can also submit these projects and tutorials to the [Google DevLibrary](https://devlibrary.withgoogle.com/)
-
 
 MediaPipe Solutions streamlines on-device ML development and deployment with flexible low-code / no-code tools that provide the modular building blocks for creating custom high-performance solutions for cross-platform deployment. It consists of the following components:
 * MediaPipe Tasks (low-code): create and deploy custom e2e ML solution pipelines
 * MediaPipe Model Maker (low-code): create custom ML models from advanced solutions
 * MediaPipe Studio (no-code): create, evaluate, debug, benchmark, prototype, deploy advanced production-level solutions
+
+## Android setup
+Run `tools/setup-android.sh` to download the Android command line tools and required SDK components before building the Android samples.

--- a/tools/setup-android.sh
+++ b/tools/setup-android.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+ANDROID_HOME=${ANDROID_HOME:-/opt/android-sdk}
+CMDLINE_URL="https://dl.google.com/android/repository/commandlinetools-linux-9123335_latest.zip"
+mkdir -p "$ANDROID_HOME/cmdline-tools"
+if [ ! -d "$ANDROID_HOME/cmdline-tools/latest" ]; then
+  tmpdir=$(mktemp -d)
+  curl -L "$CMDLINE_URL" -o "$tmpdir/cmdline.zip"
+  unzip -q "$tmpdir/cmdline.zip" -d "$tmpdir"
+  mv "$tmpdir/cmdline-tools" "$ANDROID_HOME/cmdline-tools/latest"
+  rm -rf "$tmpdir"
+fi
+export PATH="$ANDROID_HOME/cmdline-tools/latest/bin:$ANDROID_HOME/platform-tools:$PATH"
+yes | sdkmanager --licenses >/dev/null
+yes | sdkmanager "platform-tools" "platforms;android-32" "build-tools;33.0.0"


### PR DESCRIPTION
## Summary
- add `setup-android.sh` to automate Android SDK setup
- document how to run the script in `README.md`

## Testing
- `./gradlew assembleDebug` for gesture_recognizer Android demo


------
https://chatgpt.com/codex/tasks/task_e_6856aea50fd08320afea890a16fa53a4