### PR TITLE
Add script for object detection build

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,16 @@
+# MediaPipe Samples Contributor Guide
+
+This repository contains official MediaPipe samples. To build the Android Object Detection sample without Android Studio, you can use the provided build script.
+
+## Building Object Detection sample from the command line
+
+1. Run the build script:
+
+   ```bash
+   tools/build-object-detection.sh
+   ```
+
+   This script installs the Android SDK (if not present) and runs Gradle to assemble the debug APK for the Object Detection sample.
+
+2. The resulting APK will be located in `examples/object_detection/android/app/build/outputs/apk/debug/`. Artifacts are not committed to the repository.
+

--- a/tools/build-object-detection.sh
+++ b/tools/build-object-detection.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+# Build the object detection Android sample without Android Studio.
+# 1. Install Android SDK if needed.
+# 2. Run Gradle to assemble the debug APK.
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SAMPLE_DIR="$ROOT_DIR/examples/object_detection/android"
+ANDROID_HOME=${ANDROID_HOME:-/opt/android-sdk}
+"$ROOT_DIR/tools/setup-android.sh"
+export ANDROID_HOME
+export PATH="$ANDROID_HOME/cmdline-tools/latest/bin:$ANDROID_HOME/platform-tools:$PATH"
+cd "$SAMPLE_DIR"
+echo "sdk.dir=$ANDROID_HOME" > local.properties
+./gradlew assembleDebug


### PR DESCRIPTION
## Summary
- add AGENTS instructions for building object detection sample
- add build-object-detection.sh script to automate the process

## Testing
- `tools/build-object-detection.sh`

------
https://chatgpt.com/codex/tasks/task_e_685d92376dac832098240da79d1d71ca